### PR TITLE
ガジェット設定でホームの「SNSメンバー全員のタイムライン」の初期表示＆読み込み件数を設定できるように

### DIFF
--- a/apps/pc_frontend/modules/timeline/templates/_timelineAll.php
+++ b/apps/pc_frontend/modules/timeline/templates/_timelineAll.php
@@ -3,7 +3,7 @@
 <script type="text/javascript">
 //<![CDATA[
 var gorgon = {
-      'limit': '<?php echo $gadget->getConfig('limit'); ?>',
+      'count': '<?php echo $gadget->getConfig('limit'); ?>',
       'post': {
 
       },

--- a/apps/pc_frontend/modules/timeline/templates/_timelineAll.php
+++ b/apps/pc_frontend/modules/timeline/templates/_timelineAll.php
@@ -3,7 +3,7 @@
 <script type="text/javascript">
 //<![CDATA[
 var gorgon = {
-      'limit': '20',
+      'limit': '<?php echo $gadget->getConfig('limit'); ?>',
       'post': {
 
       },

--- a/config/gadget.yml
+++ b/config/gadget.yml
@@ -6,6 +6,19 @@ timelineAll:
     ja_JP: "SNSメンバー全員のタイムラインが表示されます。"
     en_US: "All SNS members' time line is displayed."
   component: [timeline, timelineAll]
+  config:
+    limit:
+      Name:      "limit"
+      Caption:   "最大表示件数"
+      FormType:  "select"
+      ValueType:  "int"
+      IsRequired: true
+      Default:    20
+      Choices:
+        5: 5
+        10: 10
+        15: 15
+        20: 20
 
 timelineMentions:
   caption:

--- a/test/fixtures/test_data.yml
+++ b/test/fixtures/test_data.yml
@@ -17,3 +17,14 @@ MemberConfig:
     name: "password"
     value: "<?php echo md5('password') ?>"
     Member: member_1
+
+Gadget:
+  timelineall_gadget:
+    type: contents
+    name: timelineAll
+
+GadgetConfig:
+  timelineall_gadget_config:
+    Gadget: timelineall_gadget
+    name: limit
+    value: 5

--- a/test/functional/pc_frontend/timelineAllGadgetTest.php
+++ b/test/functional/pc_frontend/timelineAllGadgetTest.php
@@ -16,5 +16,5 @@ $browser->get('/')
 $gadget = Doctrine::getTable('Gadget')->findOneByName('timelineAll');
 $html = get_component('timeline', 'timelineAll', array('gadget' => $gadget));
 
-$browser->test()->ok(false !== strpos($html, '\'limit\': \'5\''));
+$browser->test()->ok(false !== strpos($html, '\'count\': \'5\''));
 

--- a/test/functional/pc_frontend/timelineAllGadgetTest.php
+++ b/test/functional/pc_frontend/timelineAllGadgetTest.php
@@ -1,0 +1,20 @@
+<?php
+
+include dirname(__FILE__).'/../../bootstrap/functional.php';
+
+$browser = new opTestFunctional(new sfBrowser(), new lime_test(null, new lime_output_color()));
+
+include dirname(__FILE__).'/../../bootstrap/database.php';
+
+$browser->login('sns@example.com', 'password');
+$browser->setCulture('en');
+
+$browser->get('/')
+  ->with('user')->isAuthenticated()
+;
+
+$gadget = Doctrine::getTable('Gadget')->findOneByName('timelineAll');
+$html = get_component('timeline', 'timelineAll', array('gadget' => $gadget));
+
+$browser->test()->ok(false !== strpos($html, '\'limit\': \'5\''));
+


### PR DESCRIPTION
公式SNSでkazumuさん http://sns.openpne.jp/member/17135 の質問を調べたついでに、ガジェット設定で変更できるようにしてみました。
デフォルトは20件にしてあります。よろしくお願いします。
